### PR TITLE
auto width footnote tables

### DIFF
--- a/sphinx_readable_theme/readable/static/readable.css_t
+++ b/sphinx_readable_theme/readable/static/readable.css_t
@@ -328,6 +328,10 @@ table.docutils {
     width: 100%;
 }
 
+table.docutils.footnote {
+    width: auto;
+}
+
 table.docutils thead,
 table.docutils tfoot {
     background: #f5f5f5;


### PR DESCRIPTION
Love the theme, just have a small correction.  When you create a `.. target-notes` directive at the end it looks odd to have the tables 100%.  This should give the tables flexibility to be the size they need to.  See screenshots below.

Width 100% (Current):
![100-percent](https://f.cloud.github.com/assets/276212/2506043/715962ac-b3a1-11e3-9f70-414ecba1b49a.png)

Width Auto (Proposed):
![auto](https://f.cloud.github.com/assets/276212/2506046/7dc5140a-b3a1-11e3-9731-8323a6d4ea2b.png)
